### PR TITLE
refactor: use final msg method

### DIFF
--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -25,7 +25,9 @@ var createCmd = &cobra.Command{
 			return
 		}
 		if !kanukaExists {
-			printError(".kanuka/ doesn't exist", fmt.Errorf("please init the project first"))
+			finalMessage := color.RedString("✗") + color.YellowString(" .kanuka/ ") + "doesn't exist\n" +
+				"please init the project with: " + color.YellowString("kanuka secrets init\n")
+			spinner.FinalMSG = finalMessage
 			return
 		}
 

--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -16,7 +16,7 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Creates and adds your public key, and gives instructions on how to gain access",
 	Run: func(cmd *cobra.Command, args []string) {
-		_, cleanup := startSpinner("Creating Kanuka file...", verbose)
+		spinner, cleanup := startSpinner("Creating Kanuka file...", verbose)
 		defer cleanup()
 
 		kanukaExists, err := secrets.DoesProjectKanukaSettingsExist()
@@ -54,11 +54,12 @@ var createCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println(color.GreenString("✓") + " Your public key has been added!")
-		fmt.Println()
-		fmt.Println(color.CyanString("To gain access to the secrets in this project:"))
-		fmt.Println("  1. " + color.WhiteString("Commit your") + color.YellowString(" .kanuka/public_keys/"+username+".pub ") + color.WhiteString("file to Git"))
-		fmt.Println("  2. " + color.WhiteString("Ask someone with permissions to grant you access with:"))
-		fmt.Println("   " + color.YellowString("kanuka secrets add "+username))
+		finalMessage := color.GreenString("✓") + " Your public key has been added!\n" +
+			color.CyanString("To gain access to the secrets in this project:\n") +
+			"  1. " + color.WhiteString("Commit your") + color.YellowString(" .kanuka/public_keys/"+username+".pub ") + color.WhiteString("file to Git\n") +
+			"  2. " + color.WhiteString("Ask someone with permissions to grant you access with:\n") +
+			"     " + color.YellowString("kanuka secrets add "+username+"\n")
+
+		spinner.FinalMSG = finalMessage
 	},
 }

--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -56,7 +56,7 @@ var createCmd = &cobra.Command{
 
 		finalMessage := color.GreenString("✓") + " Your public key has been added!\n" +
 			color.CyanString("To gain access to the secrets in this project:\n") +
-			"  1. " + color.WhiteString("Commit your") + color.YellowString(" .kanuka/public_keys/"+username+".pub ") + color.WhiteString("file to Git\n") +
+			"  1. " + color.WhiteString("Commit your") + color.YellowString(" .kanuka/public_keys/"+username+".pub ") + color.WhiteString("file to your version control system\n") +
 			"  2. " + color.WhiteString("Ask someone with permissions to grant you access with:\n") +
 			"     " + color.YellowString("kanuka secrets add "+username+"\n")
 

--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -25,8 +25,8 @@ var createCmd = &cobra.Command{
 			return
 		}
 		if !kanukaExists {
-			finalMessage := color.RedString("✗") + color.YellowString(" .kanuka/ ") + "doesn't exist\n" +
-				"please init the project with: " + color.YellowString("kanuka secrets init\n")
+			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
+				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -58,14 +58,19 @@ var decryptCmd = &cobra.Command{
 		// Step 2: Get project's encrypted symmetric key
 		encryptedSymKey, err := secrets.GetUserProjectKanukaKey()
 		if err != nil {
-			printError("Failed to get user's .kanuka file", err)
+			finalMessage := color.RedString("✗") + " Failed to obtain your " +
+				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
+				"Error: " + color.RedString(err.Error()) + "\n"
+			spinner.FinalMSG = finalMessage
 			return
 		}
 		verboseLog("🔑 Loaded user's .kanuka key")
 
 		privateKey, err := secrets.GetUserPrivateKey()
 		if err != nil {
-			printError("Failed to get user's private key", err)
+			finalMessage := color.RedString("✗") + " Failed to get your private key file. Are you sure you have access?\n" +
+				"Error: " + color.RedString(err.Error()) + "\n"
+			spinner.FinalMSG = finalMessage
 			return
 		}
 		verboseLog("🔑 Loaded user's private key")
@@ -80,11 +85,15 @@ var decryptCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
+
 		verboseLog("🔓 Decrypted symmetric key")
 
 		// Step 4: Decrypt all .kanuka files
 		if err := secrets.DecryptFiles(symKey, listOfKanukaFiles, verbose); err != nil {
-			printError("Failed to decrypt environment files", err)
+			finalMessage := color.RedString("✗") + " Failed to decrypt the project's " +
+				color.YellowString(".kanuka") + " files. Are you sure you have access?\n" +
+				"Error: " + color.RedString(err.Error()) + "\n"
+			spinner.FinalMSG = finalMessage
 			return
 		}
 

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -48,7 +48,7 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 		if len(listOfKanukaFiles) == 0 {
-			finalMessage := color.RedString("✗") + " No environment files found in " + color.YellowString(workingDirectory) + "\n"
+			finalMessage := color.RedString("✗") + " No encrypted environment (" + color.YellowString(".kanuka") + ") files found in " + color.YellowString(workingDirectory) + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -73,7 +73,11 @@ var decryptCmd = &cobra.Command{
 		// Step 3: Decrypt user's kanuka file (get symmetric key)
 		symKey, err := secrets.DecryptWithPrivateKey(encryptedSymKey, privateKey)
 		if err != nil {
-			printError("Failed to decrypt symmetric key", err)
+			finalMessage := color.RedString("✗") + " Failed to decrypt your " +
+				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
+				"Error: " + color.RedString(err.Error()) + "\n"
+
+			spinner.FinalMSG = finalMessage
 			return
 		}
 		verboseLog("🔓 Decrypted symmetric key")

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -48,7 +48,8 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 		if len(listOfKanukaFiles) == 0 {
-			printError("No environment files found", fmt.Errorf("no .env.kanuka files in %v", workingDirectory))
+			finalMessage := color.RedString("✗") + " No environment files found in " + color.YellowString(workingDirectory) + "\n"
+			spinner.FinalMSG = finalMessage
 			return
 		}
 

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -85,7 +85,7 @@ var decryptCmd = &cobra.Command{
 		}
 
 		finalMessage := color.GreenString("✓") + " Environment files decrypted successfully!\n" +
-			color.CyanString("→") + " Your .env files are now ready to use\n"
+			color.CyanString("→") + " Your environment files are now ready to use\n"
 
 		spinner.FinalMSG = finalMessage
 	},

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -60,7 +60,7 @@ var decryptCmd = &cobra.Command{
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to obtain your " +
 				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
-				"Error: " + color.RedString(err.Error()) + "\n"
+				color.RedString("Error: ") + err.Error() + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
@@ -69,7 +69,7 @@ var decryptCmd = &cobra.Command{
 		privateKey, err := secrets.GetUserPrivateKey()
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to get your private key file. Are you sure you have access?\n" +
-				"Error: " + color.RedString(err.Error()) + "\n"
+				color.RedString("Error: ") + err.Error() + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
@@ -80,7 +80,7 @@ var decryptCmd = &cobra.Command{
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to decrypt your " +
 				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
-				"Error: " + color.RedString(err.Error()) + "\n"
+				color.RedString("Error: ") + err.Error() + "\n"
 
 			spinner.FinalMSG = finalMessage
 			return
@@ -92,7 +92,7 @@ var decryptCmd = &cobra.Command{
 		if err := secrets.DecryptFiles(symKey, listOfKanukaFiles, verbose); err != nil {
 			finalMessage := color.RedString("✗") + " Failed to decrypt the project's " +
 				color.YellowString(".kanuka") + " files. Are you sure you have access?\n" +
-				"Error: " + color.RedString(err.Error()) + "\n"
+				color.RedString("Error: ") + err.Error() + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -17,7 +17,7 @@ var decryptCmd = &cobra.Command{
 	Use:   "decrypt",
 	Short: "Decrypts the .env.kanuka file back into .env using your Kanuka key",
 	Run: func(cmd *cobra.Command, args []string) {
-		_, cleanup := startSpinner("Decrypting environment files...", verbose)
+		spinner, cleanup := startSpinner("Decrypting environment files...", verbose)
 		defer cleanup()
 
 		kanukaExists, err := secrets.DoesProjectKanukaSettingsExist()
@@ -81,7 +81,9 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println(color.GreenString("✓") + " Environment files decrypted successfully!")
-		fmt.Println(color.CyanString("→") + " Your .env files are now ready to use")
+		finalMessage := color.GreenString("✓") + " Environment files decrypted successfully!\n" +
+			color.CyanString("→") + " Your .env files are now ready to use\n"
+
+		spinner.FinalMSG = finalMessage
 	},
 }

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -88,7 +88,17 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 
+		// we can be sure they exist if the previous function ran without errors
+		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(workingDirectory, []string{}, false)
+		if err != nil {
+			printError("Failed to find environment files", err)
+			return
+		}
+
+		formattedListOfFiles := secrets.FormatPaths(listOfEnvFiles)
+
 		finalMessage := color.GreenString("✓") + " Environment files decrypted successfully!\n" +
+			"The following files were created:" + formattedListOfFiles +
 			color.CyanString("→") + " Your environment files are now ready to use\n"
 
 		spinner.FinalMSG = finalMessage

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -26,8 +26,8 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 		if !kanukaExists {
-			finalMessage := color.RedString("✗") + color.YellowString(" .kanuka/ ") + "doesn't exist\n" +
-				"please init the project with: " + color.YellowString("kanuka secrets init\n")
+			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
+				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -26,7 +26,9 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 		if !kanukaExists {
-			printError(".kanuka/ doesn't exist", fmt.Errorf("please init the project first with `kanuka init`"))
+			finalMessage := color.RedString("✗") + color.YellowString(" .kanuka/ ") + "doesn't exist\n" +
+				"please init the project with: " + color.YellowString("kanuka secrets init\n")
+			spinner.FinalMSG = finalMessage
 			return
 		}
 

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -60,7 +60,7 @@ var encryptCmd = &cobra.Command{
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to get your " +
 				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
-				"Error: " + color.RedString(err.Error()) + "\n"
+				color.RedString("Error: ") + err.Error() + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
@@ -69,7 +69,7 @@ var encryptCmd = &cobra.Command{
 		privateKey, err := secrets.GetUserPrivateKey()
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to get your private key file. Are you sure you have access?\n" +
-				"Error: " + color.RedString(err.Error()) + "\n"
+				color.RedString("Error: ") + err.Error() + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
@@ -80,7 +80,7 @@ var encryptCmd = &cobra.Command{
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to decrypt your " +
 				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
-				"Error: " + color.RedString(err.Error()) + "\n"
+				color.RedString("Error: ") + err.Error() + "\n"
 
 			spinner.FinalMSG = finalMessage
 			return
@@ -92,7 +92,7 @@ var encryptCmd = &cobra.Command{
 		if err := secrets.EncryptFiles(symKey, listOfEnvFiles, verbose); err != nil {
 			finalMessage := color.RedString("✗") + " Failed to encrypt the project's " +
 				color.YellowString(".env") + " files. Are you sure you have access?\n" +
-				"Error: " + color.RedString(err.Error()) + "\n"
+				color.RedString("Error: ") + err.Error() + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -89,7 +89,17 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 
+		// we can be sure they exist if the previous function ran without errors
+		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(workingDirectory, []string{}, true)
+		if err != nil {
+			printError("Failed to find environment files", err)
+			return
+		}
+
+		formattedListOfFiles := secrets.FormatPaths(listOfKanukaFiles)
+
 		finalMessage := color.GreenString("✓") + " Environment files encrypted successfully!\n" +
+			"The following files were created: " + formattedListOfFiles +
 			color.CyanString("→") + " You can now safely commit all " + color.YellowString(".kanuka") + " files in your repository\n"
 
 		spinner.FinalMSG = finalMessage

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -58,14 +58,19 @@ var encryptCmd = &cobra.Command{
 		// Step 2: Get project's encrypted symmetric key
 		encryptedSymKey, err := secrets.GetUserProjectKanukaKey()
 		if err != nil {
-			printError("Failed to get user's .kanuka file", err)
+			finalMessage := color.RedString("✗") + " Failed to get your " +
+				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
+				"Error: " + color.RedString(err.Error()) + "\n"
+			spinner.FinalMSG = finalMessage
 			return
 		}
 		verboseLog("🔑 Loaded user's .kanuka key")
 
 		privateKey, err := secrets.GetUserPrivateKey()
 		if err != nil {
-			printError("Failed to get user's private key", err)
+			finalMessage := color.RedString("✗") + " Failed to get your private key file. Are you sure you have access?\n" +
+				"Error: " + color.RedString(err.Error()) + "\n"
+			spinner.FinalMSG = finalMessage
 			return
 		}
 		verboseLog("🔑 Loaded user's private key")
@@ -85,7 +90,10 @@ var encryptCmd = &cobra.Command{
 
 		// Step 4: Encrypt all env files
 		if err := secrets.EncryptFiles(symKey, listOfEnvFiles, verbose); err != nil {
-			printError("Failed to encrypt environment files", err)
+			finalMessage := color.RedString("✗") + " Failed to encrypt the project's " +
+				color.YellowString(".env") + " files. Are you sure you have access?\n" +
+				"Error: " + color.RedString(err.Error()) + "\n"
+			spinner.FinalMSG = finalMessage
 			return
 		}
 

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -48,7 +48,8 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 		if len(listOfEnvFiles) == 0 {
-			printError("No environment files found", fmt.Errorf("no .env files in %v", workingDirectory))
+			finalMessage := color.RedString("✗") + " No environment files found in " + color.YellowString(workingDirectory) + "\n"
+			spinner.FinalMSG = finalMessage
 			return
 		}
 

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -26,8 +26,8 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 		if !kanukaExists {
-			finalMessage := color.RedString("✗") + color.YellowString(" .kanuka/ ") + "doesn't exist\n" +
-				"please init the project with: " + color.YellowString("kanuka secrets init\n")
+			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
+				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -17,7 +17,7 @@ var encryptCmd = &cobra.Command{
 	Use:   "encrypt",
 	Short: "Encrypts the .env file into .env.kanuka using your Kanuka key",
 	Run: func(cmd *cobra.Command, args []string) {
-		_, cleanup := startSpinner("Encrypting environment files...", verbose)
+		spinner, cleanup := startSpinner("Encrypting environment files...", verbose)
 		defer cleanup()
 
 		kanukaExists, err := secrets.DoesProjectKanukaSettingsExist()
@@ -81,7 +81,9 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println(color.GreenString("✓") + " Environment files encrypted successfully!")
-		fmt.Println(color.CyanString("→") + " You can now safely commit all " + color.YellowString(".kanuka") + " files in your repository")
+		finalMessage := color.GreenString("✓") + " Environment files encrypted successfully!\n" +
+			color.CyanString("→") + " You can now safely commit all " + color.YellowString(".kanuka") + " files in your repository\n"
+
+		spinner.FinalMSG = finalMessage
 	},
 }

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -26,7 +26,9 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 		if !kanukaExists {
-			printError(".kanuka/ doesn't exist", fmt.Errorf("please init the project first with `kanuka init`"))
+			finalMessage := color.RedString("✗") + color.YellowString(" .kanuka/ ") + "doesn't exist\n" +
+				"please init the project with: " + color.YellowString("kanuka secrets init\n")
+			spinner.FinalMSG = finalMessage
 			return
 		}
 

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -73,9 +73,14 @@ var encryptCmd = &cobra.Command{
 		// Step 3: Decrypt user's kanuka file (get symmetric key)
 		symKey, err := secrets.DecryptWithPrivateKey(encryptedSymKey, privateKey)
 		if err != nil {
-			printError("Failed to decrypt symmetric key", err)
+			finalMessage := color.RedString("✗") + " Failed to decrypt your " +
+				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
+				"Error: " + color.RedString(err.Error()) + "\n"
+
+			spinner.FinalMSG = finalMessage
 			return
 		}
+
 		verboseLog("🔓 Decrypted symmetric key")
 
 		// Step 4: Encrypt all env files

--- a/cmd/secrets_init.go
+++ b/cmd/secrets_init.go
@@ -25,7 +25,7 @@ var initCmd = &cobra.Command{
 			return
 		}
 		if kanukaExists {
-			finalMessage := color.RedString("✗") + color.YellowString(" .kanuka/ ") + "already exists\n" +
+			finalMessage := color.RedString("✗") + "Kanuka has already been initialized\n" +
 				"please use " + color.YellowString("kanuka secrets create") + " instead\n"
 			spinner.FinalMSG = finalMessage
 			return

--- a/cmd/secrets_init.go
+++ b/cmd/secrets_init.go
@@ -25,7 +25,9 @@ var initCmd = &cobra.Command{
 			return
 		}
 		if kanukaExists {
-			printError(".kanuka/ already exists", fmt.Errorf("please use `kanuka secrets create` instead"))
+			finalMessage := color.RedString("✗") + color.YellowString(" .kanuka/ ") + "already exists\n" +
+				"please use " + color.YellowString("kanuka secrets create") + " instead\n"
+			spinner.FinalMSG = finalMessage
 			return
 		}
 

--- a/cmd/secrets_init.go
+++ b/cmd/secrets_init.go
@@ -16,7 +16,7 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initializes the secrets store",
 	Run: func(cmd *cobra.Command, args []string) {
-		_, cleanup := startSpinner("Initialising Kanuka...", verbose)
+		spinner, cleanup := startSpinner("Initializing Kanuka...", verbose)
 		defer cleanup()
 
 		kanukaExists, err := secrets.DoesProjectKanukaSettingsExist()
@@ -59,7 +59,9 @@ var initCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println(color.GreenString("✓") + " Kanuka initialized successfully!")
-		fmt.Println(color.CyanString("→") + " Run 'kanuka secrets encrypt' to encrypt your existing .env files")
+		finalMessage := color.GreenString("✓") + " Kanuka initialized successfully!\n" +
+			color.CyanString("→") + " Run 'kanuka secrets encrypt' to encrypt your existing .env files\n"
+
+		spinner.FinalMSG = finalMessage
 	},
 }

--- a/cmd/secrets_init.go
+++ b/cmd/secrets_init.go
@@ -62,7 +62,7 @@ var initCmd = &cobra.Command{
 		}
 
 		finalMessage := color.GreenString("✓") + " Kanuka initialized successfully!\n" +
-			color.CyanString("→") + " Run 'kanuka secrets encrypt' to encrypt your existing .env files\n"
+			color.CyanString("→") + " Run " + color.YellowString("kanuka secrets encrypt") + " to encrypt your existing .env files\n"
 
 		spinner.FinalMSG = finalMessage
 	},

--- a/cmd/secrets_init.go
+++ b/cmd/secrets_init.go
@@ -25,8 +25,8 @@ var initCmd = &cobra.Command{
 			return
 		}
 		if kanukaExists {
-			finalMessage := color.RedString("✗") + "Kanuka has already been initialized\n" +
-				"please use " + color.YellowString("kanuka secrets create") + " instead\n"
+			finalMessage := color.RedString("✗") + " Kanuka has already been initialized\n" +
+				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets create") + " instead\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}


### PR DESCRIPTION
Stacked on #28 

The spinner package conveniently provides a `finalMSG` field which you can set to be any string, and at the end of your function it will display that string.

### Achieved

- Refactor all success messages to use the new spinner final message field.
- Refactor common failure cases (but not necessarily error cases) with the final message field.

### Next Steps

- Have a think about how to deal with errors. Many things that are currently treated as errors are really when the program has ran successfully, but the user is missing something. An example would be the program fails (rightfully so) if it is unable to decrypt a file, but whether or not the failure to decrypt is because of an error or if the user doesn't have access is something that needs to be dealt with.