### PR TITLE
feat: find project root

### DIFF
--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -19,12 +19,12 @@ var createCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Creating Kanuka file...", verbose)
 		defer cleanup()
 
-		kanukaExists, err := secrets.DoesProjectKanukaSettingsExist()
+		projectRoot, err := secrets.FindProjectKanukaRoot()
 		if err != nil {
 			printError("Failed to check if project kanuka settings exists", err)
 			return
 		}
-		if !kanukaExists {
+		if projectRoot == "" {
 			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
 				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
 			spinner.FinalMSG = finalMessage

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"kanuka/internal/secrets"
-	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -34,21 +33,15 @@ var decryptCmd = &cobra.Command{
 
 		verboseLog("🚀 Starting decryption process...")
 
-		// Step 1: Check for .env.kanuka file
-		workingDirectory, err := os.Getwd()
-		if err != nil {
-			printError("Failed to get working directory", err)
-			return
-		}
-
+		// Step 1: Check for .kanuka files
 		// TODO: In future, add config options to list which dirs to ignore. .kanuka/ ignored by default
-		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(workingDirectory, []string{}, true)
+		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, true)
 		if err != nil {
 			printError("Failed to find environment files", err)
 			return
 		}
 		if len(listOfKanukaFiles) == 0 {
-			finalMessage := color.RedString("✗") + " No encrypted environment (" + color.YellowString(".kanuka") + ") files found in " + color.YellowString(workingDirectory) + "\n"
+			finalMessage := color.RedString("✗") + " No encrypted environment (" + color.YellowString(".kanuka") + ") files found in " + color.YellowString(projectRoot) + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
@@ -98,7 +91,7 @@ var decryptCmd = &cobra.Command{
 		}
 
 		// we can be sure they exist if the previous function ran without errors
-		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(workingDirectory, []string{}, false)
+		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, false)
 		if err != nil {
 			printError("Failed to find environment files", err)
 			return

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -21,7 +21,7 @@ var decryptCmd = &cobra.Command{
 
 		projectRoot, err := secrets.FindProjectKanukaRoot()
 		if err != nil {
-			printError("Failed to check if project kanuka settings exists", err)
+			printError("Failed to obtain project root", err)
 			return
 		}
 		if projectRoot == "" {

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -20,12 +20,12 @@ var decryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Decrypting environment files...", verbose)
 		defer cleanup()
 
-		kanukaExists, err := secrets.DoesProjectKanukaSettingsExist()
+		projectRoot, err := secrets.FindProjectKanukaRoot()
 		if err != nil {
 			printError("Failed to check if project kanuka settings exists", err)
 			return
 		}
-		if !kanukaExists {
+		if projectRoot == "" {
 			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
 				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
 			spinner.FinalMSG = finalMessage

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"kanuka/internal/secrets"
-	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -35,20 +34,14 @@ var encryptCmd = &cobra.Command{
 		verboseLog("🚀 Starting encryption process...")
 
 		// Step 1: Check for .env file
-		workingDirectory, err := os.Getwd()
-		if err != nil {
-			printError("Failed to get working directory", err)
-			return
-		}
-
 		// TODO: In future, add config options to list which dirs to ignore. .kanuka/ ignored by default
-		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(workingDirectory, []string{}, false)
+		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, false)
 		if err != nil {
 			printError("Failed to find environment files", err)
 			return
 		}
 		if len(listOfEnvFiles) == 0 {
-			finalMessage := color.RedString("✗") + " No environment files found in " + color.YellowString(workingDirectory) + "\n"
+			finalMessage := color.RedString("✗") + " No environment files found in " + color.YellowString(projectRoot) + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
@@ -98,7 +91,7 @@ var encryptCmd = &cobra.Command{
 		}
 
 		// we can be sure they exist if the previous function ran without errors
-		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(workingDirectory, []string{}, true)
+		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, true)
 		if err != nil {
 			printError("Failed to find environment files", err)
 			return

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -20,12 +20,12 @@ var encryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Encrypting environment files...", verbose)
 		defer cleanup()
 
-		kanukaExists, err := secrets.DoesProjectKanukaSettingsExist()
+		projectRoot, err := secrets.FindProjectKanukaRoot()
 		if err != nil {
 			printError("Failed to check if project kanuka settings exists", err)
 			return
 		}
-		if !kanukaExists {
+		if projectRoot == "" {
 			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
 				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
 			spinner.FinalMSG = finalMessage

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -21,7 +21,7 @@ var encryptCmd = &cobra.Command{
 
 		projectRoot, err := secrets.FindProjectKanukaRoot()
 		if err != nil {
-			printError("Failed to check if project kanuka settings exists", err)
+			printError("Failed to obtain project root", err)
 			return
 		}
 		if projectRoot == "" {

--- a/internal/secrets/filesystem.go
+++ b/internal/secrets/filesystem.go
@@ -55,16 +55,27 @@ func DoesProjectKanukaSettingsExist() (bool, error) {
 
 // FindProjectKanukaRoot traverses up directories to find the project's Kanuka root.
 // Returns the path to the project root if found, empty string otherwise.
+// Stops searching when it reaches the user's home directory.
 func FindProjectKanukaRoot() (string, error) {
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("failed to get working directory: %w", err)
 	}
 
+	// Get the user's home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+
 	for {
+		// Stop searching at home directory
+		if currentDir == homeDir {
+			return "", nil
+		}
+
 		kanukaDir := filepath.Join(currentDir, ".kanuka")
 		fileInfo, err := os.Stat(kanukaDir)
-
 		// No error means the path exists
 		if err == nil {
 			if fileInfo.IsDir() {
@@ -81,7 +92,6 @@ func FindProjectKanukaRoot() (string, error) {
 		if parentDir == currentDir {
 			return "", nil
 		}
-
 		currentDir = parentDir
 	}
 }

--- a/internal/secrets/filesystem.go
+++ b/internal/secrets/filesystem.go
@@ -53,6 +53,39 @@ func DoesProjectKanukaSettingsExist() (bool, error) {
 	return true, nil
 }
 
+// FindProjectKanukaRoot traverses up directories to find the project's Kanuka root.
+// Returns the path to the project root if found, empty string otherwise.
+func FindProjectKanukaRoot() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	for {
+		kanukaDir := filepath.Join(currentDir, ".kanuka")
+		fileInfo, err := os.Stat(kanukaDir)
+
+		// No error means the path exists
+		if err == nil {
+			if fileInfo.IsDir() {
+				return currentDir, nil
+			}
+		} else if !os.IsNotExist(err) {
+			// Return any error that's not "file not found" (like permission issues)
+			return "", fmt.Errorf("error checking for .kanuka directory at %s: %w", currentDir, err)
+		}
+
+		parentDir := filepath.Dir(currentDir)
+
+		// If we've reached the filesystem root and haven't found .kanuka
+		if parentDir == currentDir {
+			return "", nil
+		}
+
+		currentDir = parentDir
+	}
+}
+
 // EnsureKanukaSettings ensures that the project's Kanuka settings directories exist.
 func EnsureKanukaSettings() error {
 	wd, err := os.Getwd()

--- a/internal/secrets/keys.go
+++ b/internal/secrets/keys.go
@@ -208,13 +208,13 @@ func CopyUserPublicKeyToProject() (string, error) {
 		return "", fmt.Errorf("failed to check for source key: %w", err)
 	}
 
-	workingDir, err := os.Getwd()
+	projectRoot, err := FindProjectKanukaRoot()
 	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
+		return "", fmt.Errorf("failed to get project root: %w", err)
 	}
 
 	// Destination directory: {project_path}/.kanuka/public_keys/{username}.pub
-	destKeyPath := filepath.Join(workingDir, ".kanuka", "public_keys", username+".pub")
+	destKeyPath := filepath.Join(projectRoot, ".kanuka", "public_keys", username+".pub")
 
 	keyData, err := os.ReadFile(sourceKeyPath)
 	if err != nil {

--- a/internal/secrets/keys.go
+++ b/internal/secrets/keys.go
@@ -235,7 +235,11 @@ func GetUserProjectKanukaKey() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get username: %w", err)
 	}
-	userKeyFile := filepath.Join(".kanuka", "secrets", fmt.Sprintf("%s.kanuka", username))
+	projectPath, err := FindProjectKanukaRoot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find project root: %w", err)
+	}
+	userKeyFile := filepath.Join(projectPath, ".kanuka", "secrets", fmt.Sprintf("%s.kanuka", username))
 	if _, err := os.Stat(userKeyFile); os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to get user's project encrypted symmetric key: %w", err)
 	}

--- a/internal/secrets/keys.go
+++ b/internal/secrets/keys.go
@@ -212,6 +212,9 @@ func CopyUserPublicKeyToProject() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get project root: %w", err)
 	}
+	if projectRoot == "" {
+		return "", fmt.Errorf("failed to find project root because it doesn't exist")
+	}
 
 	// Destination directory: {project_path}/.kanuka/public_keys/{username}.pub
 	destKeyPath := filepath.Join(projectRoot, ".kanuka", "public_keys", username+".pub")
@@ -235,11 +238,15 @@ func GetUserProjectKanukaKey() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get username: %w", err)
 	}
-	projectPath, err := FindProjectKanukaRoot()
+	projectRoot, err := FindProjectKanukaRoot()
 	if err != nil {
 		return nil, fmt.Errorf("failed to find project root: %w", err)
 	}
-	userKeyFile := filepath.Join(projectPath, ".kanuka", "secrets", fmt.Sprintf("%s.kanuka", username))
+	if projectRoot == "" {
+		return nil, fmt.Errorf("failed to find project root because it doesn't exist")
+	}
+
+	userKeyFile := filepath.Join(projectRoot, ".kanuka", "secrets", fmt.Sprintf("%s.kanuka", username))
 	if _, err := os.Stat(userKeyFile); os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to get user's project encrypted symmetric key: %w", err)
 	}

--- a/internal/secrets/project.go
+++ b/internal/secrets/project.go
@@ -2,16 +2,15 @@ package secrets
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 )
 
 // GetProjectName returns the name of the current project (directory).
 func GetProjectName() (string, error) {
-	workingDirectory, err := os.Getwd()
+	projectDirectory, err := FindProjectKanukaRoot()
 	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
+		return "", fmt.Errorf("failed to get project directory: %w", err)
 	}
-	projectName := filepath.Base(workingDirectory)
+	projectName := filepath.Base(projectDirectory)
 	return projectName, nil
 }

--- a/internal/secrets/project.go
+++ b/internal/secrets/project.go
@@ -7,10 +7,13 @@ import (
 
 // GetProjectName returns the name of the current project (directory).
 func GetProjectName() (string, error) {
-	projectDirectory, err := FindProjectKanukaRoot()
+	projectRoot, err := FindProjectKanukaRoot()
 	if err != nil {
 		return "", fmt.Errorf("failed to get project directory: %w", err)
 	}
-	projectName := filepath.Base(projectDirectory)
+	if projectRoot == "" {
+		return "", fmt.Errorf("failed to find project root because it doesn't exist")
+	}
+	projectName := filepath.Base(projectRoot)
 	return projectName, nil
 }


### PR DESCRIPTION
Stacked on #30 

closes #25 

### Achieved

- Created method for finding project root (based on `.kanuka/` existing, so projects have to be init first). 
- Make `encrypt`, `decrypt`, and `create` use project root to create files.