### PR TITLE
style: lowercase help messages (small PR)

### DIFF
--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -11,7 +11,7 @@ import (
 var force bool
 
 func init() {
-	createCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	createCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 	createCmd.Flags().BoolVarP(&force, "force", "f", false, "force key creation")
 }
 

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	decryptCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	decryptCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 }
 
 var decryptCmd = &cobra.Command{

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	encryptCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	encryptCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 }
 
 var encryptCmd = &cobra.Command{

--- a/cmd/secrets_init.go
+++ b/cmd/secrets_init.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	initCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	initCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 }
 
 var initCmd = &cobra.Command{


### PR DESCRIPTION
Stacked on #33 

### Achieved

- Have lowercase for help messages on `--help` (as that is the cobra default).