### PR TITLE
refactor: remove verbose logs (Small PR)

### DIFF
--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"kanuka/internal/secrets"
 
 	"github.com/fatih/color"
@@ -34,8 +33,6 @@ var createCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
-
-		verboseLog("Adding your public key...")
 
 		if err := secrets.EnsureUserSettings(); err != nil {
 			printError("Failed ensuring user settings", err)
@@ -72,9 +69,9 @@ var createCmd = &cobra.Command{
 			printError("Failed to copy public key to project", err)
 			return
 		}
-		verboseLog(fmt.Sprintf("✅ Copied public key into %s", destPath))
 
-		finalMessage := color.GreenString("✓") + " Your public key has been added!\n" +
+		finalMessage := color.GreenString("✓") + " Your public key has been added to the following location:\n" +
+			"    - " + color.YellowString(destPath) + "\n" +
 			color.CyanString("To gain access to the secrets in this project:\n") +
 			"  1. " + color.WhiteString("Commit your") + color.YellowString(" .kanuka/public_keys/"+currentUsername+".pub ") + color.WhiteString("file to your version control system\n") +
 			"  2. " + color.WhiteString("Ask someone with permissions to grant you access with:\n") +

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"kanuka/internal/secrets"
 	"os"
 	"path/filepath"
@@ -33,8 +32,6 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 
-		verboseLog("🚀 Starting decryption process...")
-
 		// Step 1: Check for .kanuka files
 		// TODO: In future, add config options to list which dirs to ignore. .kanuka/ ignored by default
 		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, true)
@@ -47,8 +44,6 @@ var decryptCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
-
-		verboseLog(fmt.Sprintf("✅ Found %d .env.kanuka files: %s", len(listOfKanukaFiles), secrets.FormatPaths(listOfKanukaFiles)))
 
 		// Step 2: Get project's encrypted symmetric key
 		currentUsername, err := secrets.GetUsername()
@@ -65,7 +60,6 @@ var decryptCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
-		verboseLog("🔑 Loaded user's .kanuka key")
 
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
@@ -82,7 +76,6 @@ var decryptCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
-		verboseLog("🔑 Loaded user's private key")
 
 		// Step 3: Decrypt user's kanuka file (get symmetric key)
 		symKey, err := secrets.DecryptWithPrivateKey(encryptedSymKey, privateKey)
@@ -94,8 +87,6 @@ var decryptCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
-
-		verboseLog("🔓 Decrypted symmetric key")
 
 		// Step 4: Decrypt all .kanuka files
 		if err := secrets.DecryptFiles(symKey, listOfKanukaFiles, verbose); err != nil {

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"kanuka/internal/secrets"
 	"os"
 	"path/filepath"
@@ -33,8 +32,6 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 
-		verboseLog("🚀 Starting encryption process...")
-
 		// Step 1: Check for .env file
 		// TODO: In future, add config options to list which dirs to ignore. .kanuka/ ignored by default
 		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, false)
@@ -47,8 +44,6 @@ var encryptCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
-
-		verboseLog(fmt.Sprintf("✅ Found %d .env files: %s", len(listOfEnvFiles), secrets.FormatPaths(listOfEnvFiles)))
 
 		// Step 2: Get project's encrypted symmetric key
 		currentUsername, err := secrets.GetUsername()
@@ -65,7 +60,6 @@ var encryptCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
-		verboseLog("🔑 Loaded user's .kanuka key")
 
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
@@ -82,7 +76,6 @@ var encryptCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
-		verboseLog("🔑 Loaded user's private key")
 
 		// Step 3: Decrypt user's kanuka file (get symmetric key)
 		symKey, err := secrets.DecryptWithPrivateKey(encryptedSymKey, privateKey)
@@ -94,8 +87,6 @@ var encryptCmd = &cobra.Command{
 			spinner.FinalMSG = finalMessage
 			return
 		}
-
-		verboseLog("🔓 Decrypted symmetric key")
 
 		// Step 4: Encrypt all env files
 		if err := secrets.EncryptFiles(symKey, listOfEnvFiles, verbose); err != nil {

--- a/cmd/secrets_helper_methods.go
+++ b/cmd/secrets_helper_methods.go
@@ -9,12 +9,6 @@ import (
 	"github.com/briandowns/spinner"
 )
 
-func verboseLog(message string) {
-	if verbose {
-		log.Println(message)
-	}
-}
-
 func printError(message string, err error) {
 	if !verbose {
 		log.SetOutput(os.Stdout)

--- a/cmd/secrets_init.go
+++ b/cmd/secrets_init.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"kanuka/internal/secrets"
 
 	"github.com/fatih/color"
@@ -31,8 +30,6 @@ var initCmd = &cobra.Command{
 			return
 		}
 
-		verboseLog("Starting Kanuka initialization...")
-
 		if err := secrets.EnsureUserSettings(); err != nil {
 			printError("Failed ensuring user settings", err)
 			return
@@ -42,7 +39,6 @@ var initCmd = &cobra.Command{
 			printError("Failed to create .kanuka folders", err)
 			return
 		}
-		verboseLog("✅ Created .kanuka folders")
 
 		if err := secrets.CreateAndSaveRSAKeyPair(verbose); err != nil {
 			printError("Failed to generate and save RSA key pair", err)
@@ -50,11 +46,11 @@ var initCmd = &cobra.Command{
 		}
 
 		destPath, err := secrets.CopyUserPublicKeyToProject()
+		_ = destPath // explicity ignore destPath for now
 		if err != nil {
 			printError("Failed to copy public key to project", err)
 			return
 		}
-		verboseLog(fmt.Sprintf("✅ Copied public key into %s", destPath))
 
 		if err := secrets.CreateAndSaveEncryptedSymmetricKey(verbose); err != nil {
 			printError("Failed to create encrypted symmetric key", err)

--- a/internal/secrets/keys.go
+++ b/internal/secrets/keys.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 )
@@ -135,11 +134,6 @@ func CreateAndSaveRSAKeyPair(verbose bool) error {
 		return fmt.Errorf("failed to generate or save RSA key pair for project %s: %w", projectName, err)
 	}
 
-	if verbose {
-		log.Printf(`✅ Successfully generated RSA keys at:
-  - Private: %s
-  - Public: %s`, privateKeyPath, publicKeyPath)
-	}
 	return nil
 }
 


### PR DESCRIPTION
Stacked on #39 

Closes #36 

I've removed verbose logging because I'm not doing it correctly at the moment. However, I've still left in the infrastructure for having a verbose flag around as I do intend to rework it later to make it better.

### Achieved

- Removed verbose logs from all methods.
- Remove the old verbose log method.
- Update the output on the create command to include where the new `.kanuka` file was created.