### PR TITLE
refactor: use shared settings

### DIFF
--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -22,7 +22,10 @@ var createCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Creating Kanuka file...", verbose)
 		defer cleanup()
 
-		configs.InitProjectSettings()
+		if err := configs.InitProjectSettings(); err != nil {
+			printError("failed to init project settings", err)
+			return
+		}
 		projectPath := configs.ProjectKanukaSettings.ProjectPath
 
 		if projectPath == "" {

--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"kanuka/internal/configs"
 	"kanuka/internal/secrets"
-	"kanuka/internal/utils"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -13,6 +13,8 @@ var force bool
 func init() {
 	createCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 	createCmd.Flags().BoolVarP(&force, "force", "f", false, "force key creation")
+
+	configs.InitProjectSettings()
 }
 
 var createCmd = &cobra.Command{
@@ -22,13 +24,9 @@ var createCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Creating Kanuka file...", verbose)
 		defer cleanup()
 
-		projectRoot, err := utils.FindProjectKanukaRoot()
-		if err != nil {
-			printError("Failed to check if project kanuka settings exists", err)
-			return
-		}
+		projectPath := configs.ProjectKanukaSettings.ProjectPath
 
-		if projectRoot == "" {
+		if projectPath == "" {
 			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
 				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
 			spinner.FinalMSG = finalMessage
@@ -40,12 +38,7 @@ var createCmd = &cobra.Command{
 			return
 		}
 
-		currentUsername, err := utils.GetUsername()
-		if err != nil {
-			printError("Failed to get username", err)
-			return
-		}
-
+		currentUsername := configs.UserKanukaSettings.Username
 		// If force flag is active, then ignore checking for existing symmetric key
 		if !force {
 			// We are explicitly ignoring errors, because an error means the key doesn't exist, which is what we want.

--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -13,8 +13,6 @@ var force bool
 func init() {
 	createCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 	createCmd.Flags().BoolVarP(&force, "force", "f", false, "force key creation")
-
-	configs.InitProjectSettings()
 }
 
 var createCmd = &cobra.Command{
@@ -24,6 +22,7 @@ var createCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Creating Kanuka file...", verbose)
 		defer cleanup()
 
+		configs.InitProjectSettings()
 		projectPath := configs.ProjectKanukaSettings.ProjectPath
 
 		if projectPath == "" {

--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"kanuka/internal/secrets"
+	"kanuka/internal/utils"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -21,7 +22,7 @@ var createCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Creating Kanuka file...", verbose)
 		defer cleanup()
 
-		projectRoot, err := secrets.FindProjectKanukaRoot()
+		projectRoot, err := utils.FindProjectKanukaRoot()
 		if err != nil {
 			printError("Failed to check if project kanuka settings exists", err)
 			return
@@ -39,7 +40,7 @@ var createCmd = &cobra.Command{
 			return
 		}
 
-		currentUsername, err := secrets.GetUsername()
+		currentUsername, err := utils.GetUsername()
 		if err != nil {
 			printError("Failed to get username", err)
 			return

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -12,8 +12,6 @@ import (
 
 func init() {
 	decryptCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
-
-	configs.InitProjectSettings()
 }
 
 var decryptCmd = &cobra.Command{
@@ -23,6 +21,7 @@ var decryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Decrypting environment files...", verbose)
 		defer cleanup()
 
+		configs.InitProjectSettings()
 		projectName := configs.ProjectKanukaSettings.ProjectName
 		projectPath := configs.ProjectKanukaSettings.ProjectPath
 

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"kanuka/internal/configs"
 	"kanuka/internal/secrets"
 	"kanuka/internal/utils"
-	"os"
 	"path/filepath"
 
 	"github.com/fatih/color"
@@ -12,6 +12,8 @@ import (
 
 func init() {
 	decryptCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
+
+	configs.InitProjectSettings()
 }
 
 var decryptCmd = &cobra.Command{
@@ -21,39 +23,32 @@ var decryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Decrypting environment files...", verbose)
 		defer cleanup()
 
-		projectRoot, err := utils.FindProjectKanukaRoot()
-		if err != nil {
-			printError("Failed to obtain project root", err)
-			return
-		}
-		if projectRoot == "" {
+		projectName := configs.ProjectKanukaSettings.ProjectName
+		projectPath := configs.ProjectKanukaSettings.ProjectPath
+
+		if projectPath == "" {
 			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
 				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
 
-		// Step 1: Check for .kanuka files
 		// TODO: In future, add config options to list which dirs to ignore. .kanuka/ ignored by default
-		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, true)
+		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(projectPath, []string{}, true)
 		if err != nil {
 			printError("Failed to find environment files", err)
 			return
 		}
 		if len(listOfKanukaFiles) == 0 {
-			finalMessage := color.RedString("✗") + " No encrypted environment (" + color.YellowString(".kanuka") + ") files found in " + color.YellowString(projectRoot) + "\n"
+			finalMessage := color.RedString("✗") + " No encrypted environment (" + color.YellowString(".kanuka") + ") files found in " + color.YellowString(projectPath) + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
 
-		// Step 2: Get project's encrypted symmetric key
-		currentUsername, err := utils.GetUsername()
-		if err != nil {
-			printError("Failed to get username", err)
-			return
-		}
+		username := configs.UserKanukaSettings.Username
+		userKeysPath := configs.UserKanukaSettings.UserKeysPath
 
-		encryptedSymKey, err := secrets.GetProjectKanukaKey(currentUsername)
+		encryptedSymKey, err := secrets.GetProjectKanukaKey(username)
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to obtain your " +
 				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
@@ -62,14 +57,7 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			printError("Failed to get user's home directory", err)
-			return
-		}
-		projectName := filepath.Base(projectRoot)
-		privateKeyPath := filepath.Join(homeDir, ".config", ".kanuka", "keys", projectName)
-
+		privateKeyPath := filepath.Join(userKeysPath, projectName)
 		privateKey, err := secrets.LoadPrivateKey(privateKeyPath)
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to get your private key file. Are you sure you have access?\n" +
@@ -78,7 +66,6 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 
-		// Step 3: Decrypt user's kanuka file (get symmetric key)
 		symKey, err := secrets.DecryptWithPrivateKey(encryptedSymKey, privateKey)
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to decrypt your " +
@@ -89,7 +76,6 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 
-		// Step 4: Decrypt all .kanuka files
 		if err := secrets.DecryptFiles(symKey, listOfKanukaFiles, verbose); err != nil {
 			finalMessage := color.RedString("✗") + " Failed to decrypt the project's " +
 				color.YellowString(".kanuka") + " files. Are you sure you have access?\n" +
@@ -99,7 +85,7 @@ var decryptCmd = &cobra.Command{
 		}
 
 		// we can be sure they exist if the previous function ran without errors
-		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, false)
+		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(projectPath, []string{}, false)
 		if err != nil {
 			printError("Failed to find environment files", err)
 			return

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"kanuka/internal/secrets"
+	"kanuka/internal/utils"
 	"os"
 	"path/filepath"
 
@@ -20,7 +21,7 @@ var decryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Decrypting environment files...", verbose)
 		defer cleanup()
 
-		projectRoot, err := secrets.FindProjectKanukaRoot()
+		projectRoot, err := utils.FindProjectKanukaRoot()
 		if err != nil {
 			printError("Failed to obtain project root", err)
 			return
@@ -46,7 +47,7 @@ var decryptCmd = &cobra.Command{
 		}
 
 		// Step 2: Get project's encrypted symmetric key
-		currentUsername, err := secrets.GetUsername()
+		currentUsername, err := utils.GetUsername()
 		if err != nil {
 			printError("Failed to get username", err)
 			return
@@ -104,7 +105,7 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 
-		formattedListOfFiles := secrets.FormatPaths(listOfEnvFiles)
+		formattedListOfFiles := utils.FormatPaths(listOfEnvFiles)
 
 		finalMessage := color.GreenString("✓") + " Environment files decrypted successfully!\n" +
 			"The following files were created:" + formattedListOfFiles +

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -67,7 +67,7 @@ var decryptCmd = &cobra.Command{
 			return
 		}
 		projectName := filepath.Base(projectRoot)
-		privateKeyPath := filepath.Join(homeDir, ".kanuka", "keys", projectName)
+		privateKeyPath := filepath.Join(homeDir, ".config", ".kanuka", "keys", projectName)
 
 		privateKey, err := secrets.LoadPrivateKey(privateKeyPath)
 		if err != nil {

--- a/cmd/secrets_decrypt.go
+++ b/cmd/secrets_decrypt.go
@@ -21,7 +21,10 @@ var decryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Decrypting environment files...", verbose)
 		defer cleanup()
 
-		configs.InitProjectSettings()
+		if err := configs.InitProjectSettings(); err != nil {
+			printError("failed to init project settings", err)
+			return
+		}
 		projectName := configs.ProjectKanukaSettings.ProjectName
 		projectPath := configs.ProjectKanukaSettings.ProjectPath
 

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"kanuka/internal/secrets"
+	"kanuka/internal/utils"
 	"os"
 	"path/filepath"
 
@@ -20,7 +21,7 @@ var encryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Encrypting environment files...", verbose)
 		defer cleanup()
 
-		projectRoot, err := secrets.FindProjectKanukaRoot()
+		projectRoot, err := utils.FindProjectKanukaRoot()
 		if err != nil {
 			printError("Failed to obtain project root", err)
 			return
@@ -46,7 +47,7 @@ var encryptCmd = &cobra.Command{
 		}
 
 		// Step 2: Get project's encrypted symmetric key
-		currentUsername, err := secrets.GetUsername()
+		currentUsername, err := utils.GetUsername()
 		if err != nil {
 			printError("Failed to get username", err)
 			return
@@ -104,7 +105,7 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 
-		formattedListOfFiles := secrets.FormatPaths(listOfKanukaFiles)
+		formattedListOfFiles := utils.FormatPaths(listOfKanukaFiles)
 
 		finalMessage := color.GreenString("✓") + " Environment files encrypted successfully!\n" +
 			"The following files were created: " + formattedListOfFiles +

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -67,7 +67,7 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 		projectName := filepath.Base(projectRoot)
-		privateKeyPath := filepath.Join(homeDir, ".kanuka", "keys", projectName)
+		privateKeyPath := filepath.Join(homeDir, ".config", ".kanuka", "keys", projectName)
 
 		privateKey, err := secrets.LoadPrivateKey(privateKeyPath)
 		if err != nil {

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -21,7 +21,10 @@ var encryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Encrypting environment files...", verbose)
 		defer cleanup()
 
-		configs.InitProjectSettings()
+		if err := configs.InitProjectSettings(); err != nil {
+			printError("failed to init project settings", err)
+			return
+		}
 		projectName := configs.ProjectKanukaSettings.ProjectName
 		projectPath := configs.ProjectKanukaSettings.ProjectPath
 

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -12,8 +12,6 @@ import (
 
 func init() {
 	encryptCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
-
-	configs.InitProjectSettings()
 }
 
 var encryptCmd = &cobra.Command{
@@ -23,6 +21,7 @@ var encryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Encrypting environment files...", verbose)
 		defer cleanup()
 
+		configs.InitProjectSettings()
 		projectName := configs.ProjectKanukaSettings.ProjectName
 		projectPath := configs.ProjectKanukaSettings.ProjectPath
 

--- a/cmd/secrets_encrypt.go
+++ b/cmd/secrets_encrypt.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"kanuka/internal/configs"
 	"kanuka/internal/secrets"
 	"kanuka/internal/utils"
-	"os"
 	"path/filepath"
 
 	"github.com/fatih/color"
@@ -12,6 +12,8 @@ import (
 
 func init() {
 	encryptCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
+
+	configs.InitProjectSettings()
 }
 
 var encryptCmd = &cobra.Command{
@@ -21,39 +23,32 @@ var encryptCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Encrypting environment files...", verbose)
 		defer cleanup()
 
-		projectRoot, err := utils.FindProjectKanukaRoot()
-		if err != nil {
-			printError("Failed to obtain project root", err)
-			return
-		}
-		if projectRoot == "" {
+		projectName := configs.ProjectKanukaSettings.ProjectName
+		projectPath := configs.ProjectKanukaSettings.ProjectPath
+
+		if projectPath == "" {
 			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
 				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
 
-		// Step 1: Check for .env file
 		// TODO: In future, add config options to list which dirs to ignore. .kanuka/ ignored by default
-		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, false)
+		listOfEnvFiles, err := secrets.FindEnvOrKanukaFiles(projectPath, []string{}, false)
 		if err != nil {
 			printError("Failed to find environment files", err)
 			return
 		}
 		if len(listOfEnvFiles) == 0 {
-			finalMessage := color.RedString("✗") + " No environment files found in " + color.YellowString(projectRoot) + "\n"
+			finalMessage := color.RedString("✗") + " No environment files found in " + color.YellowString(projectPath) + "\n"
 			spinner.FinalMSG = finalMessage
 			return
 		}
 
-		// Step 2: Get project's encrypted symmetric key
-		currentUsername, err := utils.GetUsername()
-		if err != nil {
-			printError("Failed to get username", err)
-			return
-		}
+		username := configs.UserKanukaSettings.Username
+		userKeysPath := configs.UserKanukaSettings.UserKeysPath
 
-		encryptedSymKey, err := secrets.GetProjectKanukaKey(currentUsername)
+		encryptedSymKey, err := secrets.GetProjectKanukaKey(username)
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to get your " +
 				color.YellowString(".kanuka") + " file. Are you sure you have access?\n" +
@@ -62,14 +57,7 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			printError("Failed to get user's home directory", err)
-			return
-		}
-		projectName := filepath.Base(projectRoot)
-		privateKeyPath := filepath.Join(homeDir, ".config", ".kanuka", "keys", projectName)
-
+		privateKeyPath := filepath.Join(userKeysPath, projectName)
 		privateKey, err := secrets.LoadPrivateKey(privateKeyPath)
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to get your private key file. Are you sure you have access?\n" +
@@ -78,7 +66,6 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 
-		// Step 3: Decrypt user's kanuka file (get symmetric key)
 		symKey, err := secrets.DecryptWithPrivateKey(encryptedSymKey, privateKey)
 		if err != nil {
 			finalMessage := color.RedString("✗") + " Failed to decrypt your " +
@@ -89,7 +76,6 @@ var encryptCmd = &cobra.Command{
 			return
 		}
 
-		// Step 4: Encrypt all env files
 		if err := secrets.EncryptFiles(symKey, listOfEnvFiles, verbose); err != nil {
 			finalMessage := color.RedString("✗") + " Failed to encrypt the project's " +
 				color.YellowString(".env") + " files. Are you sure you have access?\n" +
@@ -99,7 +85,7 @@ var encryptCmd = &cobra.Command{
 		}
 
 		// we can be sure they exist if the previous function ran without errors
-		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(projectRoot, []string{}, true)
+		listOfKanukaFiles, err := secrets.FindEnvOrKanukaFiles(projectPath, []string{}, true)
 		if err != nil {
 			printError("Failed to find environment files", err)
 			return

--- a/cmd/secrets_register.go
+++ b/cmd/secrets_register.go
@@ -18,8 +18,6 @@ func init() {
 		printError("Failed to mark --user flag as required", err)
 		return
 	}
-
-	configs.InitProjectSettings()
 }
 
 var registerCmd = &cobra.Command{
@@ -29,6 +27,7 @@ var registerCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Registering user for access...", verbose)
 		defer cleanup()
 
+		configs.InitProjectSettings()
 		currentUsername := configs.UserKanukaSettings.Username
 		currentUserKeysPath := configs.UserKanukaSettings.UserKeysPath
 

--- a/cmd/secrets_register.go
+++ b/cmd/secrets_register.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"kanuka/internal/secrets"
+	"kanuka/internal/utils"
 	"os"
 	"path/filepath"
 
@@ -27,7 +28,7 @@ var registerCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Registering user for access...", verbose)
 		defer cleanup()
 
-		projectRoot, err := secrets.FindProjectKanukaRoot()
+		projectRoot, err := utils.FindProjectKanukaRoot()
 		if err != nil {
 			printError("Failed to check if project kanuka settings exists", err)
 			return
@@ -51,7 +52,7 @@ var registerCmd = &cobra.Command{
 		}
 
 		// Get current user's encrypted symmetric key
-		currentUsername, err := secrets.GetUsername()
+		currentUsername, err := utils.GetUsername()
 		if err != nil {
 			printError("Failed to get username", err)
 			return

--- a/cmd/secrets_register.go
+++ b/cmd/secrets_register.go
@@ -70,7 +70,7 @@ var registerCmd = &cobra.Command{
 			return
 		}
 		projectName := filepath.Base(projectRoot)
-		privateKeyPath := filepath.Join(homeDir, ".kanuka", "keys", projectName)
+		privateKeyPath := filepath.Join(homeDir, ".config", ".kanuka", "keys", projectName)
 
 		privateKey, err := secrets.LoadPrivateKey(privateKeyPath)
 		if err != nil {

--- a/cmd/secrets_register.go
+++ b/cmd/secrets_register.go
@@ -27,7 +27,10 @@ var registerCmd = &cobra.Command{
 		spinner, cleanup := startSpinner("Registering user for access...", verbose)
 		defer cleanup()
 
-		configs.InitProjectSettings()
+		if err := configs.InitProjectSettings(); err != nil {
+			printError("failed to init project settings", err)
+			return
+		}
 		currentUsername := configs.UserKanukaSettings.Username
 		currentUserKeysPath := configs.UserKanukaSettings.UserKeysPath
 

--- a/internal/configs/settings.go
+++ b/internal/configs/settings.go
@@ -1,0 +1,76 @@
+package configs
+
+import (
+	"kanuka/internal/utils"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+type UserSettings struct {
+	UserKeysPath    string
+	UserConfigsPath string
+	Username        string
+}
+
+type ProjectSettings struct {
+	ProjectUUID          string
+	ProjectName          string
+	ProjectPath          string
+	ProjectPublicKeyPath string
+	ProjectSecretsPath   string
+}
+
+var (
+	UserKanukaSettings    *UserSettings
+	ProjectKanukaSettings *ProjectSettings
+)
+
+func init() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("error getting home directory: %s", err)
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		log.Fatalf("error getting config directory: %s", err)
+	}
+
+	dataDir := os.Getenv("XDG_DATA_HOME")
+
+	if dataDir == "" {
+		dataDir = filepath.Join(homeDir, ".local", "share")
+	}
+
+	username, err := utils.GetUsername()
+	if err != nil {
+		log.Fatalf("error getting username: %s", err)
+	}
+
+	// This is independent of what repo you are in, so it is ok to init here
+	UserKanukaSettings = &UserSettings{
+		UserKeysPath:    filepath.Join(dataDir, "kanuka", "keys"),
+		UserConfigsPath: filepath.Join(configDir, "kanuka"),
+		Username:        username,
+	}
+}
+
+func InitProjectSettings() {
+	projectName, err := utils.GetProjectName()
+	if err != nil {
+		log.Fatalf("error getting project name: %s", err)
+	}
+
+	projectPath, err := utils.FindProjectKanukaRoot()
+	if err != nil {
+		log.Fatalf("error getting project root: %s", err)
+	}
+
+	ProjectKanukaSettings = &ProjectSettings{
+		ProjectName:          projectName,
+		ProjectPath:          projectPath,
+		ProjectPublicKeyPath: filepath.Join(projectPath, ".kanuka", "public_keys"),
+		ProjectSecretsPath:   filepath.Join(projectPath, ".kanuka", "secrets"),
+	}
+}

--- a/internal/configs/settings.go
+++ b/internal/configs/settings.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"fmt"
 	"kanuka/internal/utils"
 	"log"
 	"os"
@@ -54,17 +55,23 @@ func init() {
 		UserConfigsPath: filepath.Join(configDir, "kanuka"),
 		Username:        username,
 	}
+	ProjectKanukaSettings = &ProjectSettings{
+		ProjectName:          "",
+		ProjectPath:          "",
+		ProjectPublicKeyPath: "",
+		ProjectSecretsPath:   "",
+	}
 }
 
-func InitProjectSettings() {
+func InitProjectSettings() error {
 	projectName, err := utils.GetProjectName()
 	if err != nil {
-		log.Fatalf("error getting project name: %s", err)
+		return fmt.Errorf("error getting project name: %w", err)
 	}
 
 	projectPath, err := utils.FindProjectKanukaRoot()
 	if err != nil {
-		log.Fatalf("error getting project root: %s", err)
+		return fmt.Errorf("error getting project root: %w", err)
 	}
 
 	ProjectKanukaSettings = &ProjectSettings{
@@ -73,4 +80,6 @@ func InitProjectSettings() {
 		ProjectPublicKeyPath: filepath.Join(projectPath, ".kanuka", "public_keys"),
 		ProjectSecretsPath:   filepath.Join(projectPath, ".kanuka", "secrets"),
 	}
+
+	return nil
 }

--- a/internal/secrets/crypto.go
+++ b/internal/secrets/crypto.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"io"
+	"kanuka/internal/utils"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,7 +39,7 @@ func CreateAndSaveEncryptedSymmetricKey(verbose bool) error {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	username, err := GetUsername()
+	username, err := utils.GetUsername()
 	if err != nil {
 		return fmt.Errorf("failed to get username: %w", err)
 	}

--- a/internal/secrets/crypto.go
+++ b/internal/secrets/crypto.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"io"
-	"kanuka/internal/utils"
+	"kanuka/internal/configs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,11 +39,9 @@ func CreateAndSaveEncryptedSymmetricKey(verbose bool) error {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	username, err := utils.GetUsername()
-	if err != nil {
-		return fmt.Errorf("failed to get username: %w", err)
-	}
+	username := configs.UserKanukaSettings.Username
 
+	// Project hasn't been made at this point yet, so do it relative to working directory.
 	kanukaDir := filepath.Join(wd, ".kanuka")
 	secretsDir := filepath.Join(kanukaDir, "secrets")
 	pubKeyPath := filepath.Join(kanukaDir, "public_keys", username+".pub")

--- a/internal/secrets/filesystem.go
+++ b/internal/secrets/filesystem.go
@@ -53,49 +53,6 @@ func DoesProjectKanukaSettingsExist() (bool, error) {
 	return true, nil
 }
 
-// FindProjectKanukaRoot traverses up directories to find the project's Kanuka root.
-// Returns the path to the project root if found, empty string otherwise.
-// Stops searching when it reaches the user's home directory.
-func FindProjectKanukaRoot() (string, error) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
-	}
-
-	// Get the user's home directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get user home directory: %w", err)
-	}
-
-	for {
-		// Stop searching at home directory
-		if currentDir == homeDir {
-			return "", nil
-		}
-
-		kanukaDir := filepath.Join(currentDir, ".kanuka")
-		fileInfo, err := os.Stat(kanukaDir)
-		// No error means the path exists
-		if err == nil {
-			if fileInfo.IsDir() {
-				return currentDir, nil
-			}
-		} else if !os.IsNotExist(err) {
-			// Return any error that's not "file not found" (like permission issues)
-			return "", fmt.Errorf("error checking for .kanuka directory at %s: %w", currentDir, err)
-		}
-
-		parentDir := filepath.Dir(currentDir)
-
-		// If we've reached the filesystem root and haven't found .kanuka
-		if parentDir == currentDir {
-			return "", nil
-		}
-		currentDir = parentDir
-	}
-}
-
 // EnsureKanukaSettings ensures that the project's Kanuka settings directories exist.
 func EnsureKanukaSettings() error {
 	wd, err := os.Getwd()

--- a/internal/secrets/filesystem.go
+++ b/internal/secrets/filesystem.go
@@ -3,28 +3,28 @@ package secrets
 import (
 	"fmt"
 	"io/fs"
+	"kanuka/internal/configs"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 )
 
-// EnsureUserSettings ensures that the user's Kanuka settings directory exists.
+// EnsureUserSettings ensures that the user's Kanuka data and config directory exists.
 func EnsureUserSettings() error {
-	currentUser, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("failed to get current user: %w", err)
-	}
-	userKanukaDirectory := filepath.Join(currentUser.HomeDir, ".config", ".kanuka", "keys")
+	userKanukaDataDirectory := configs.UserKanukaSettings.UserKeysPath
+	userKanukaConfigDirectory := configs.UserKanukaSettings.UserConfigsPath
 
-	if err := os.MkdirAll(userKanukaDirectory, 0700); err != nil {
-		return fmt.Errorf("failed to create %s: %w", userKanukaDirectory, err)
+	if err := os.MkdirAll(userKanukaDataDirectory, 0700); err != nil {
+		return fmt.Errorf("failed to create %s: %w", userKanukaDataDirectory, err)
+	}
+	if err := os.MkdirAll(userKanukaConfigDirectory, 0700); err != nil {
+		return fmt.Errorf("failed to create %s: %w", userKanukaConfigDirectory, err)
 	}
 
 	return nil
 }
 
-// DoesProjectKanukaSettingsExist checks if the project's Kanuka settings directory exists.
+// DoesProjectKanukaSettingsExist checks if the project has been init already.
 func DoesProjectKanukaSettingsExist() (bool, error) {
 	workingDirectory, err := os.Getwd()
 	if err != nil {

--- a/internal/secrets/filesystem.go
+++ b/internal/secrets/filesystem.go
@@ -15,7 +15,7 @@ func EnsureUserSettings() error {
 	if err != nil {
 		return fmt.Errorf("failed to get current user: %w", err)
 	}
-	userKanukaDirectory := filepath.Join(currentUser.HomeDir, ".kanuka", "keys")
+	userKanukaDirectory := filepath.Join(currentUser.HomeDir, ".config", ".kanuka", "keys")
 
 	if err := os.MkdirAll(userKanukaDirectory, 0700); err != nil {
 		return fmt.Errorf("failed to create %s: %w", userKanukaDirectory, err)

--- a/internal/secrets/keys.go
+++ b/internal/secrets/keys.go
@@ -45,7 +45,7 @@ func LoadPublicKey(path string) (*rsa.PublicKey, error) {
 }
 
 // GenerateRSAKeyPair creates a new RSA key pair and saves them to disk.
-func GenerateRSAKeyPair(privatePath, publicPath string) error {
+func GenerateRSAKeyPair(privatePath string, publicPath string) error {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return fmt.Errorf("failed to generate RSA key pair: %w", err)
@@ -121,7 +121,7 @@ func CreateAndSaveRSAKeyPair(verbose bool) error {
 	}
 
 	// Create key paths
-	keysDir := filepath.Join(homeDir, ".kanuka", "keys")
+	keysDir := filepath.Join(homeDir, ".config", ".kanuka", "keys")
 	privateKeyPath := filepath.Join(keysDir, projectName)
 	publicKeyPath := privateKeyPath + ".pub"
 
@@ -154,8 +154,8 @@ func CopyUserPublicKeyToProject() (string, error) {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
 
-	// Source path: ~/.kanuka/keys/{project_name}.pub
-	sourceKeyPath := filepath.Join(homeDir, ".kanuka", "keys", projectName+".pub")
+	// Source path: ~/.config/.kanuka/keys/{project_name}.pub
+	sourceKeyPath := filepath.Join(homeDir, ".config", ".kanuka", "keys", projectName+".pub")
 
 	// Check if source key exists
 	if _, err := os.Stat(sourceKeyPath); err != nil {

--- a/internal/secrets/keys.go
+++ b/internal/secrets/keys.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"kanuka/internal/utils"
 	"os"
 	"path/filepath"
 )
@@ -139,12 +140,12 @@ func CreateAndSaveRSAKeyPair(verbose bool) error {
 
 // CopyUserPublicKeyToProject copies the user's public key to the project directory.
 func CopyUserPublicKeyToProject() (string, error) {
-	username, err := GetUsername()
+	username, err := utils.GetUsername()
 	if err != nil {
 		return "", fmt.Errorf("failed to get username: %w", err)
 	}
 
-	projectName, err := GetProjectName()
+	projectName, err := utils.GetProjectName()
 	if err != nil {
 		return "", fmt.Errorf("failed to get project name: %w", err)
 	}
@@ -165,7 +166,7 @@ func CopyUserPublicKeyToProject() (string, error) {
 		return "", fmt.Errorf("failed to check for source key: %w", err)
 	}
 
-	projectRoot, err := FindProjectKanukaRoot()
+	projectRoot, err := utils.FindProjectKanukaRoot()
 	if err != nil {
 		return "", fmt.Errorf("failed to get project root: %w", err)
 	}
@@ -190,7 +191,7 @@ func CopyUserPublicKeyToProject() (string, error) {
 }
 
 func SaveKanukaKeyToProject(username string, kanukaKey []byte) error {
-	projectRoot, err := FindProjectKanukaRoot()
+	projectRoot, err := utils.FindProjectKanukaRoot()
 	if err != nil {
 		return fmt.Errorf("failed to get project root: %w", err)
 	}
@@ -208,7 +209,7 @@ func SaveKanukaKeyToProject(username string, kanukaKey []byte) error {
 
 // GetUserProjectKanukaKey retrieves the encrypted symmetric key for the current user and project.
 func GetProjectKanukaKey(username string) ([]byte, error) {
-	projectRoot, err := FindProjectKanukaRoot()
+	projectRoot, err := utils.FindProjectKanukaRoot()
 	if err != nil {
 		return nil, fmt.Errorf("failed to find project root: %w", err)
 	}

--- a/internal/secrets/keys.go
+++ b/internal/secrets/keys.go
@@ -110,11 +110,10 @@ func GenerateRSAKeyPair(privatePath string, publicPath string) error {
 
 // CreateAndSaveRSAKeyPair generates a new RSA key pair for the project and saves them in the user's directory.
 func CreateAndSaveRSAKeyPair(verbose bool) error {
-	wd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get current working directory: %w", err)
+	if err := configs.InitProjectSettings(); err != nil {
+		return fmt.Errorf("failed to init project settings: %w", err)
 	}
-	projectName := filepath.Base(wd)
+	projectName := configs.ProjectKanukaSettings.ProjectName
 
 	// Create key paths
 	keysDir := configs.UserKanukaSettings.UserKeysPath
@@ -135,7 +134,9 @@ func CreateAndSaveRSAKeyPair(verbose bool) error {
 
 // CopyUserPublicKeyToProject copies the user's public key to the project directory.
 func CopyUserPublicKeyToProject() (string, error) {
-	configs.InitProjectSettings()
+	if err := configs.InitProjectSettings(); err != nil {
+		return "", fmt.Errorf("failed to init project settings: %w", err)
+	}
 
 	username := configs.UserKanukaSettings.Username
 	projectName := configs.ProjectKanukaSettings.ProjectName
@@ -167,7 +168,9 @@ func CopyUserPublicKeyToProject() (string, error) {
 }
 
 func SaveKanukaKeyToProject(username string, kanukaKey []byte) error {
-	configs.InitProjectSettings()
+	if err := configs.InitProjectSettings(); err != nil {
+		return fmt.Errorf("failed to init project settings: %w", err)
+	}
 
 	projectPath := configs.ProjectKanukaSettings.ProjectPath
 	projectSecretsPath := configs.ProjectKanukaSettings.ProjectSecretsPath
@@ -187,7 +190,9 @@ func SaveKanukaKeyToProject(username string, kanukaKey []byte) error {
 
 // GetUserProjectKanukaKey retrieves the encrypted symmetric key for the current user and project.
 func GetProjectKanukaKey(username string) ([]byte, error) {
-	configs.InitProjectSettings()
+	if err := configs.InitProjectSettings(); err != nil {
+		return nil, fmt.Errorf("failed to init project settings: %w", err)
+	}
 
 	projectPath := configs.ProjectKanukaSettings.ProjectPath
 	projectSecretsPath := configs.ProjectKanukaSettings.ProjectSecretsPath

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 )
 
@@ -22,8 +23,8 @@ func FindProjectKanukaRoot() (string, error) {
 	}
 
 	for {
-		// Stop searching at home directory
-		if currentDir == homeDir {
+		// Stop searching at one level above home directory
+		if currentDir == path.Join(homeDir, "..") {
 			return "", nil
 		}
 

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FindProjectKanukaRoot traverses up directories to find the project's Kanuka root.
+// Returns the path to the project root if found, empty string otherwise.
+// Stops searching when it reaches the user's home directory.
+func FindProjectKanukaRoot() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Get the user's home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+
+	for {
+		// Stop searching at home directory
+		if currentDir == homeDir {
+			return "", nil
+		}
+
+		kanukaDir := filepath.Join(currentDir, ".kanuka")
+		fileInfo, err := os.Stat(kanukaDir)
+		// No error means the path exists
+		if err == nil {
+			if fileInfo.IsDir() {
+				return currentDir, nil
+			}
+		} else if !os.IsNotExist(err) {
+			// Return any error that's not "file not found" (like permission issues)
+			return "", fmt.Errorf("error checking for .kanuka directory at %s: %w", currentDir, err)
+		}
+
+		parentDir := filepath.Dir(currentDir)
+
+		// If we've reached the filesystem root and haven't found .kanuka
+		if parentDir == currentDir {
+			return "", nil
+		}
+		currentDir = parentDir
+	}
+}

--- a/internal/utils/project.go
+++ b/internal/utils/project.go
@@ -11,8 +11,11 @@ func GetProjectName() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get project directory: %w", err)
 	}
+	// If the project doesn't exist, then the project name doesn't exist either
+	// but don't throw an error because it will cause a crash when a non-init command
+	// is run on a repo that hasn't been intialised
 	if projectRoot == "" {
-		return "", fmt.Errorf("failed to find project root because it doesn't exist")
+		return "", nil
 	}
 	projectName := filepath.Base(projectRoot)
 	return projectName, nil

--- a/internal/utils/project.go
+++ b/internal/utils/project.go
@@ -1,4 +1,4 @@
-package secrets
+package utils
 
 import (
 	"fmt"

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -1,20 +1,10 @@
-package secrets
+package utils
 
 import (
-	"os/user"
 	"strings"
 
 	"github.com/fatih/color"
 )
-
-// GetUsername returns the current username.
-func GetUsername() (string, error) {
-	user, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-	return user.Username, nil
-}
 
 // FormatPaths formats a slice of paths into a readable string.
 func FormatPaths(paths []string) string {

--- a/internal/utils/system.go
+++ b/internal/utils/system.go
@@ -1,0 +1,12 @@
+package utils
+
+import "os/user"
+
+// GetUsername returns the current username.
+func GetUsername() (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return user.Username, nil
+}


### PR DESCRIPTION
Stacked on #40 

Closes #22 
Closes #42 
Closes #41 
Closes #48

### Achieved

- Finally move out methods that don't belong in the `secrets` package into a `utils` package.
- Create a new package called `configs`, which hold all the shared variables (such as username, key paths, project name, etc). One positive of this implementation is that we are now complaint with the [XDG Base Directory Specifications](https://specifications.freedesktop.org/basedir-spec/latest/). 
- Change the locations of where keys and configs are stored. Configs are now stored in `~/.config/kanuka/`, `~/Library/Application Support`, or `%AppData%` (currently unused, but will be used later). Keys are stored in `~/.local/share/`, as according to `XDG_DATA_HOME`.
- Refactor all the methods that used to rely on creating paths and usernames to now use `UserKanukaSettings` and `ProjectKanukaSettings` respectively.
- Make the method for searching root go up another level (that is, one more level than `$HOME`).
- Fixed the issue with `kanuka secrets create` not replacing the pub key file from a subdirectory.
- `kanuka secrets init` and `kanuka secrets create` now work from your home directory.

### Known Errors

~~Right now, when you try and `kanuka secrets init` or `kanuka secrets create` in your home directory, it doesn't work because there's a name clash between the username and the "project name" (home directory aka username).~~ Fixed now

