### PR TITLE
feat: `--force` flag improved

### DIFF
--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -52,7 +52,7 @@ var createCmd = &cobra.Command{
 			userPublicKey, _ := secrets.LoadPublicKey(userPublicKeyPath)
 
 			if userPublicKey != nil {
-				finalMessage := color.RedString("✗ ") + color.YellowString(currentUsername+".kanuka ") + "already exists\n" +
+				finalMessage := color.RedString("✗ ") + color.YellowString(currentUsername+".pub ") + "already exists\n" +
 					"To override, run: " + color.YellowString("kanuka secrets create --force\n")
 				spinner.FinalMSG = finalMessage
 				return


### PR DESCRIPTION
Stacked on #43 

Closes #45 
Closes #46
Closes #47 
Closes #24 
Closes #23 

With this feature, I've decided against explicitly confirming with the user that their action is destructive. To reach this stage, they had to have ran `kanuka secrets create` and have it *fail*, and read through the message that tells them they're about to override an existing public key.

### Achieved

- `--force` flag now checks against the `.pub` file instead of the `.kanuka` file.
- `--force` flag now also removes the old (and now permanently locked and useless) `.kanuka` file, and displays the changes in the final message if applicable.
