### PR TITLE
feat: add `--file` flag for register

### DIFF
--- a/cmd/secrets_register.go
+++ b/cmd/secrets_register.go
@@ -130,3 +130,86 @@ func handleUserRegistration(spinner *spinner.Spinner) {
 	spinner.FinalMSG = finalMessage
 }
 
+func handleCustomFileRegistration(spinner *spinner.Spinner) {
+	currentUsername := configs.UserKanukaSettings.Username
+	currentUserKeysPath := configs.UserKanukaSettings.UserKeysPath
+
+	projectName := configs.ProjectKanukaSettings.ProjectName
+	projectPath := configs.ProjectKanukaSettings.ProjectPath
+
+	if projectPath == "" {
+		finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
+			color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	if !strings.HasSuffix(customFilePath, ".pub") {
+		finalMessage := color.RedString("✗ ") + color.YellowString(customFilePath) + " is not a valid path to a public key file.\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	// Load the custom public key
+	targetUserPublicKey, err := secrets.LoadPublicKey(customFilePath)
+	if err != nil {
+		finalMessage := color.RedString("✗") + " Public key could not be loaded from " + color.YellowString(customFilePath) + "\n\n" +
+			color.RedString("Error: ") + err.Error() + "\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	projectSecretsPath := configs.ProjectKanukaSettings.ProjectSecretsPath
+	kanukaKeyPath := filepath.Join(projectSecretsPath, currentUsername+".kanuka")
+
+	encryptedSymKey, err := secrets.GetProjectKanukaKey(currentUsername)
+	if err != nil {
+		finalMessage := color.RedString("✗") + " Couldn't get your Kanuka key from " + color.YellowString(kanukaKeyPath) + "\n\n" +
+			"Are you sure you have access?\n\n" +
+			color.RedString("Error: ") + err.Error() + "\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	// Get current user's private key
+	privateKeyPath := filepath.Join(currentUserKeysPath, projectName)
+
+	privateKey, err := secrets.LoadPrivateKey(privateKeyPath)
+	if err != nil {
+		finalMessage := color.RedString("✗") + " Couldn't get your private key from " + color.YellowString(privateKeyPath) + "\n\n" +
+			"Are you sure you have access?\n\n" +
+			color.RedString("Error: ") + err.Error() + "\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	// Decrypt symmetric key with current user's private key
+	symKey, err := secrets.DecryptWithPrivateKey(encryptedSymKey, privateKey)
+	if err != nil {
+		finalMessage := color.RedString("✗") + " Failed to decrypt your Kanuka key using your private key: \n" +
+			"    Kanuka key path: " + color.YellowString(kanukaKeyPath) + "\n" +
+			"    Private key path: " + color.YellowString(privateKeyPath) + "\n\n" +
+			"Are you sure you have access?\n\n" +
+			color.RedString("Error: ") + err.Error() + "\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	// Encrypt symmetric key with target user's public key
+	targetEncryptedSymKey, err := secrets.EncryptWithPublicKey(symKey, targetUserPublicKey)
+	if err != nil {
+		printError("Failed to encrypt symmetric key for target user", err)
+		return
+	}
+
+	// Save encrypted symmetric key for target user
+	targetName := strings.TrimSuffix(filepath.Base(customFilePath), ".pub")
+	if err := secrets.SaveKanukaKeyToProject(targetName, targetEncryptedSymKey); err != nil {
+		printError("Failed to save encrypted key for target user", err)
+		return
+	}
+
+	finalMessage := color.GreenString("✓") + " Public key " + color.YellowString(targetName+".pub") + " has been registered successfully!\n" +
+		color.CyanString("→") + " They now have access to decrypt the repository's secrets\n"
+	spinner.FinalMSG = finalMessage
+}

--- a/cmd/secrets_register.go
+++ b/cmd/secrets_register.go
@@ -9,15 +9,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var username string
+var (
+	username       string
+	customFilePath string
+)
 
 func init() {
 	registerCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 	registerCmd.Flags().StringVarP(&username, "user", "u", "", "username to register for access")
-	if err := registerCmd.MarkFlagRequired("user"); err != nil {
-		printError("Failed to mark --user flag as required", err)
-		return
-	}
+	registerCmd.Flags().StringVarP(&customFilePath, "file", "f", "", "the path to a custom public key — will add public key to the project")
 }
 
 var registerCmd = &cobra.Command{
@@ -26,6 +26,13 @@ var registerCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		spinner, cleanup := startSpinner("Registering user for access...", verbose)
 		defer cleanup()
+
+		if username == "" && customFilePath == "" {
+			finalMessage := color.RedString("✗") + " Either " + color.YellowString("--user") + " or " + color.YellowString("--file") + " must be specified.\n" +
+				"Please run " + color.YellowString("kanuka secrets register --help") + " to see the available commands.\n"
+			spinner.FinalMSG = finalMessage
+			return
+		}
 
 		if err := configs.InitProjectSettings(); err != nil {
 			printError("failed to init project settings", err)

--- a/cmd/secrets_register.go
+++ b/cmd/secrets_register.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -39,103 +40,93 @@ var registerCmd = &cobra.Command{
 			printError("failed to init project settings", err)
 			return
 		}
-		currentUsername := configs.UserKanukaSettings.Username
-		currentUserKeysPath := configs.UserKanukaSettings.UserKeysPath
-
-		projectName := configs.ProjectKanukaSettings.ProjectName
-		projectPath := configs.ProjectKanukaSettings.ProjectPath
-		projectPublicKeyPath := configs.ProjectKanukaSettings.ProjectPublicKeyPath
-
-		if projectPath == "" {
-			finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
-				color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
-			spinner.FinalMSG = finalMessage
-			return
-		}
-
-		// Check if target user's public key exists
-		targetPubkeyPath := filepath.Join(projectPublicKeyPath, username+".pub")
 
 		if customFilePath != "" {
-			if !strings.HasSuffix(customFilePath, ".pub") {
-				finalMessage := color.RedString("✗ ") + color.YellowString(customFilePath) + " is not a valid path to a public key file.\n"
-				spinner.FinalMSG = finalMessage
-				return
-			}
-			targetPubkeyPath = customFilePath
+			handleCustomFileRegistration(spinner)
+		} else {
+			handleUserRegistration(spinner)
 		}
-
-		// TODO: In the future, differentiate between FileNotFound Error and InvalidKey Error
-		targetUserPublicKey, err := secrets.LoadPublicKey(targetPubkeyPath)
-		if err != nil {
-			if customFilePath != "" {
-				finalMessage := color.RedString("✗") + " Public key could not be loaded from " + color.YellowString(customFilePath) + "\n\n" +
-					color.RedString("Error: ") + err.Error() + "\n"
-				spinner.FinalMSG = finalMessage
-				return
-			}
-
-			finalMessage := color.RedString("✗") + " Public key for user " + color.YellowString(username) + " not found\n" +
-				username + " must first run: " + color.YellowString("kanuka secrets create\n")
-			spinner.FinalMSG = finalMessage
-			return
-		}
-
-		projectSecretsPath := configs.ProjectKanukaSettings.ProjectSecretsPath
-		kanukaKeyPath := filepath.Join(projectSecretsPath, currentUsername+".kanuka")
-
-		encryptedSymKey, err := secrets.GetProjectKanukaKey(currentUsername)
-		if err != nil {
-			finalMessage := color.RedString("✗") + " Couldn't get your Kanuka key from " + color.YellowString(kanukaKeyPath) + "\n\n" +
-				"Are you sure you have access?\n\n" +
-				color.RedString("Error: ") + err.Error() + "\n"
-			spinner.FinalMSG = finalMessage
-			return
-		}
-
-		// Get current user's private key
-		privateKeyPath := filepath.Join(currentUserKeysPath, projectName)
-
-		privateKey, err := secrets.LoadPrivateKey(privateKeyPath)
-		if err != nil {
-			finalMessage := color.RedString("✗") + " Couldn't get your private key from " + color.YellowString(privateKeyPath) + "\n\n" +
-				"Are you sure you have access?\n\n" +
-				color.RedString("Error: ") + err.Error() + "\n"
-			spinner.FinalMSG = finalMessage
-			return
-		}
-
-		// Decrypt symmetric key with current user's private key
-		symKey, err := secrets.DecryptWithPrivateKey(encryptedSymKey, privateKey)
-		if err != nil {
-			finalMessage := color.RedString("✗") + " Failed to decrypt your Kanuka key using your private key: \n" +
-				"    Kanuka key path: " + color.YellowString(kanukaKeyPath) + "\n" +
-				"    Private key path: " + color.YellowString(privateKeyPath) + "\n\n" +
-				"Are you sure you have access?\n\n" +
-				color.RedString("Error: ") + err.Error() + "\n"
-			spinner.FinalMSG = finalMessage
-			return
-		}
-
-		// Encrypt symmetric key with target user's public key
-		targetEncryptedSymKey, err := secrets.EncryptWithPublicKey(symKey, targetUserPublicKey)
-		if err != nil {
-			printError("Failed to encrypt symmetric key for target user", err)
-			return
-		}
-
-		// Save encrypted symmetric key for target user
-		targetName := username
-		if customFilePath != "" {
-			targetName = strings.TrimSuffix(filepath.Base(customFilePath), ".pub")
-		}
-		if err := secrets.SaveKanukaKeyToProject(targetName, targetEncryptedSymKey); err != nil {
-			printError("Failed to save encrypted key for target user", err)
-			return
-		}
-
-		finalMessage := color.GreenString("✓") + " Public key " + color.YellowString(targetName+".pub") + " has been registered successfully!\n" +
-			color.CyanString("→") + " They now have access to decrypt the repository's secrets\n"
-		spinner.FinalMSG = finalMessage
 	},
 }
+
+func handleUserRegistration(spinner *spinner.Spinner) {
+	currentUsername := configs.UserKanukaSettings.Username
+	currentUserKeysPath := configs.UserKanukaSettings.UserKeysPath
+
+	projectName := configs.ProjectKanukaSettings.ProjectName
+	projectPath := configs.ProjectKanukaSettings.ProjectPath
+	projectPublicKeyPath := configs.ProjectKanukaSettings.ProjectPublicKeyPath
+
+	if projectPath == "" {
+		finalMessage := color.RedString("✗") + " Kanuka has not been initialized\n" +
+			color.CyanString("→") + " Please run " + color.YellowString("kanuka secrets init") + " instead\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	// Check if target user's public key exists
+	targetPubkeyPath := filepath.Join(projectPublicKeyPath, username+".pub")
+
+	// TODO: In the future, differentiate between FileNotFound Error and InvalidKey Error
+	targetUserPublicKey, err := secrets.LoadPublicKey(targetPubkeyPath)
+	if err != nil {
+		finalMessage := color.RedString("✗") + " Public key for user " + color.YellowString(username) + " not found\n" +
+			username + " must first run: " + color.YellowString("kanuka secrets create\n")
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	projectSecretsPath := configs.ProjectKanukaSettings.ProjectSecretsPath
+	kanukaKeyPath := filepath.Join(projectSecretsPath, currentUsername+".kanuka")
+
+	encryptedSymKey, err := secrets.GetProjectKanukaKey(currentUsername)
+	if err != nil {
+		finalMessage := color.RedString("✗") + " Couldn't get your Kanuka key from " + color.YellowString(kanukaKeyPath) + "\n\n" +
+			"Are you sure you have access?\n\n" +
+			color.RedString("Error: ") + err.Error() + "\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	// Get current user's private key
+	privateKeyPath := filepath.Join(currentUserKeysPath, projectName)
+
+	privateKey, err := secrets.LoadPrivateKey(privateKeyPath)
+	if err != nil {
+		finalMessage := color.RedString("✗") + " Couldn't get your private key from " + color.YellowString(privateKeyPath) + "\n\n" +
+			"Are you sure you have access?\n\n" +
+			color.RedString("Error: ") + err.Error() + "\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	// Decrypt symmetric key with current user's private key
+	symKey, err := secrets.DecryptWithPrivateKey(encryptedSymKey, privateKey)
+	if err != nil {
+		finalMessage := color.RedString("✗") + " Failed to decrypt your Kanuka key using your private key: \n" +
+			"    Kanuka key path: " + color.YellowString(kanukaKeyPath) + "\n" +
+			"    Private key path: " + color.YellowString(privateKeyPath) + "\n\n" +
+			"Are you sure you have access?\n\n" +
+			color.RedString("Error: ") + err.Error() + "\n"
+		spinner.FinalMSG = finalMessage
+		return
+	}
+
+	// Encrypt symmetric key with target user's public key
+	targetEncryptedSymKey, err := secrets.EncryptWithPublicKey(symKey, targetUserPublicKey)
+	if err != nil {
+		printError("Failed to encrypt symmetric key for target user", err)
+		return
+	}
+
+	// Save encrypted symmetric key for target user
+	if err := secrets.SaveKanukaKeyToProject(username, targetEncryptedSymKey); err != nil {
+		printError("Failed to save encrypted key for target user", err)
+		return
+	}
+
+	finalMessage := color.GreenString("✓") + " Public key " + color.YellowString(username+".pub") + " has been registered successfully!\n" +
+		color.CyanString("→") + " They now have access to decrypt the repository's secrets\n"
+	spinner.FinalMSG = finalMessage
+}
+

--- a/cmd/secrets_register.go
+++ b/cmd/secrets_register.go
@@ -4,6 +4,7 @@ import (
 	"kanuka/internal/configs"
 	"kanuka/internal/secrets"
 	"path/filepath"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -54,6 +55,15 @@ var registerCmd = &cobra.Command{
 
 		// Check if target user's public key exists
 		targetPubkeyPath := filepath.Join(projectPublicKeyPath, username+".pub")
+
+		if customFilePath != "" {
+			if !strings.HasSuffix(customFilePath, ".pub") {
+				finalMessage := color.RedString("✗ ") + color.YellowString(customFilePath) + " is not a valid path to a public key file.\n"
+				spinner.FinalMSG = finalMessage
+				return
+			}
+			targetPubkeyPath = customFilePath
+		}
 
 		targetUserPublicKey, err := secrets.LoadPublicKey(targetPubkeyPath)
 		if err != nil {

--- a/cmd/secrets_register.go
+++ b/cmd/secrets_register.go
@@ -134,7 +134,7 @@ var registerCmd = &cobra.Command{
 			return
 		}
 
-		finalMessage := color.GreenString("✓") + " Public key " + color.YellowString(targetName) + " has been registered successfully!\n" +
+		finalMessage := color.GreenString("✓") + " Public key " + color.YellowString(targetName+".pub") + " has been registered successfully!\n" +
 			color.CyanString("→") + " They now have access to decrypt the repository's secrets\n"
 		spinner.FinalMSG = finalMessage
 	},


### PR DESCRIPTION
Stacked on #51 

Closes #53 

### Achieved

- A new `--file` flag, which takes in the path to a public key.
- Validates if the path is actually a public key (if ends with `.pub`), and if the contents is a public key (`LoadPublicKey` method).
- Update error messages to be clearer and to use spinner's final message on "happy paths" (code execution where things haven't failed due to errors but rather lack of requirements).